### PR TITLE
Add global-autogen to standard source directories.

### DIFF
--- a/main/mafia.hs
+++ b/main/mafia.hs
@@ -750,7 +750,7 @@ appendStandardDirs dir =
 
 standardSourceDirs :: [Directory]
 standardSourceDirs =
-  ["src", "test", "gen", "dist/build", "dist/build/autogen"]
+  ["src", "test", "gen", "dist/build", "dist/build/autogen", "dist/build/global-autogen"]
 
 ensureDirectory :: MonadIO m => Directory -> m (Maybe Directory)
 ensureDirectory dir = do


### PR DESCRIPTION
For ghc 8.2 / cabal 2 / dependency generating Setup.hs.